### PR TITLE
Move `getting started` links to separate folder

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,11 +7,11 @@
 
 ## Awesome Google Developer Challenge: Mobile Web Specialist 2017/2018
 
-A curated list of awesome resources for recipients of the [Google Developer Challenge Scholarship](https://www.udacity.com/google-scholarships) 2017/2018  
-Inspired by [awesome lists](https://github.com/sindresorhus/awesome)  
+A curated list of awesome resources for recipients of the [Google Developer Challenge Scholarship](https://www.udacity.com/google-scholarships) 2017/2018
+Inspired by [awesome lists](https://github.com/sindresorhus/awesome).
 ### Contribution
 
-Feedback and contributions are always welcome and appreciated.  
+Feedback and contributions are always welcome and appreciated.
 You can contribute interesting links to articles, presentations, videos, podcasts etc that might be helpful for our community.
 
 
@@ -19,8 +19,7 @@ You can contribute interesting links to articles, presentations, videos, podcast
 
 ### Just getting started?
 
-- [Getting Started and Prerequisites](https://discussions.udacity.com/t/getting-started-and-prerequisites/418485?u=haitec) (Udacity Discussion Forum)
-- [Video: Jake Archibald about progressive apps](https://www.youtube.com/watch?v=cmGr0RszHc8) (from Google I/O 2016)
+[Take a look here!](gettingStarted/README.md)
 
 ## Content
 

--- a/gettingStarted/README.md
+++ b/gettingStarted/README.md
@@ -1,0 +1,3 @@
+- [Getting Started and Prerequisites](https://discussions.udacity.com/t/getting-started-and-prerequisites/418485?u=haitec) (Udacity Discussion Forum)
+
+- [Video: Jake Archibald about progressive apps](https://www.youtube.com/watch?v=cmGr0RszHc8) (from Google I/O 2016)


### PR DESCRIPTION
I thought that it may be useful to move `getting started` to separate folder and separate readme - we could add more links, like for example those that you suggested @Agheb ([How to use GIT and Github](https://www.udacity.com/course/how-to-use-git-and-github--ud775), [Writing READMEs](https://www.udacity.com/course/writing-readmes--ud777)) 