### PR TITLE
Add Slack links and format for Further Learning 

### DIFF
--- a/furtherLearning/README.md
+++ b/furtherLearning/README.md
@@ -20,6 +20,10 @@ Jake Archibald shares the future of the web app model, with Foreign Fetch, Strea
 
 * [The Net Ninja](https://www.youtube.com/channel/UCW5YeuERMmlnqo4oq8vwUpg/playlists)
 * [Computerphile](https://www.youtube.com/user/Computerphile)
+* [Google Developer](https://www.youtube.com/channel/UC_x5XG1OV2P6uZZ5FSM9Ttw)
+* [Traversy Media](https://www.youtube.com/channel/UC29ju8bIPH5as8OGnQzwJyA)
+* [The Coding Train](https://www.youtube.com/channel/UCvjgXvBlbQiydffZU7m1_aw)
+* [MIT](https://www.youtube.com/channel/UCEBb1b_L6zDS3xTUrIALZOw)
 
 ## Courses
 


### PR DESCRIPTION
I cleaned up the `further learning` readme and added a new format: HTML & CSS, Javascript and Youtube Channels.

A lot has to do with Javascript but there are still topics that are not related to Javascript like "Accelerated Mobile Pages" which belongs to HTML.

Youtube Channels now has its own section at the bottom since they serve for further learning but are not specific to HTML, CSS or Javascript. 

I moved also some of the` further learning` links to the `introduction` and added overall links to the `introduction` and` further learning` readme from the Slack `#resource` channel

Preview: https://github.com/Mycroft1891/awesome-google-mobile-web-challenge-links-2017/blob/master/furtherLearning/README.md